### PR TITLE
Update the way that the CLI accepts input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,10 +137,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ed2379f8603fa2b7509891660e802b88c70a79a6427a70abb5968054de2c28"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72394f3339a76daf211e57d4bcb374410f3965dcc606dd0e03738c7888766980"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e9ef9a08ee1c0e1f2e162121665ac45ac3783b0f897db7244ae75ad9a8f65b"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "config"
@@ -233,6 +336,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "euclid"
 version = "0.20.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +406,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +461,7 @@ dependencies = [
 name = "kehadiran-parser"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "config",
  "lazy_static",
  "pdf-extract",
@@ -327,6 +487,12 @@ name = "linked-hash-map"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "log"
@@ -562,6 +728,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.37.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,6 +876,12 @@ name = "stdweb-internal-runtime"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -838,6 +1024,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,6 +1122,72 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.3.1", features = ["derive"] }
 config = "0.13.1"
 lazy_static = "1.4.0"
 pdf-extract = "0.6.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use std::collections::HashSet;
 use std::fs;
 use std::fs::File;
 use std::io::prelude::*;
+use std::path::Path;
 
 #[derive(Serialize, Deserialize)]
 struct ParliamentMeeting {
@@ -35,41 +36,38 @@ lazy_static! {
     static ref NAME_REGEX: Regex = Regex::new(r"[A-Z()][\w,’'()@/\.\- ]+").unwrap();
 }
 
-pub fn run(pdf_dir: String, out_dir: String) -> i32 {
-    println!("Starting: pdf_dir={}, out_dir={}", pdf_dir, out_dir);
-    if let Ok(entries) = fs::read_dir(pdf_dir) {
-        for entry in entries {
-            if let Ok(entry) = entry {
-                let file_path = entry.path();
-                if file_path.is_dir() {
-                    continue;
-                }
-                if let Some(ext) = file_path.extension() {
-                    if ext != "pdf" {
-                        continue;
-                    }
-                } else {
-                    continue;
-                }
-                println!("Processing: pdf_file={}", file_path.display());
-                let bytes = std::fs::read(file_path.display().to_string()).unwrap();
-                let content = pdf_extract::extract_text_from_mem(&bytes).unwrap();
-                let json_file_path = file_path
-                    .display()
-                    .to_string()
-                    .trim_end_matches(".pdf")
-                    .clone()
-                    .to_owned()
-                    + ".json";
-                if let Ok(mut json_file) = File::create(json_file_path) {
-                    let parsed = parse(content);
-                    let json_string = serde_json::to_string_pretty(&parsed).unwrap();
-                    if let Ok(()) = json_file.write_all(json_string.as_bytes()) {}
-                }
+pub fn run(pdf_dir: &Path, _: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let entries = fs::read_dir(pdf_dir)?;
+    for entry in entries {
+        let entry = entry?;
+        let file_path = entry.path();
+        if file_path.is_dir() {
+            continue;
+        }
+        if let Some(ext) = file_path.extension() {
+            if ext != "pdf" {
+                continue;
             }
+        } else {
+            continue;
+        }
+        println!("Processing: pdf_file={}", file_path.display());
+        let bytes = std::fs::read(file_path.display().to_string())?;
+        let content = pdf_extract::extract_text_from_mem(&bytes)?;
+        let json_file_path = file_path
+            .display()
+            .to_string()
+            .trim_end_matches(".pdf")
+            .clone()
+            .to_owned()
+            + ".json";
+        if let Ok(mut json_file) = File::create(json_file_path) {
+            let parsed = parse(content);
+            let json_string = serde_json::to_string_pretty(&parsed)?;
+            json_file.write_all(json_string.as_bytes())?;
         }
     }
-    0
+    Ok(())
 }
 
 fn parse(content: String) -> ParliamentMeeting {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,15 +2,15 @@ use std::{path::PathBuf, str::FromStr};
 
 use clap::Parser;
 
-/// Simple program to greet a person
+/// Program to parse PDF of Malaysian MPs attendance
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// Name of the person to greet
+    /// Path to the PDF directory
     #[arg(short, long)]
     pdf_dir: String,
 
-    /// Number of times to greet
+    /// Path to the output directory
     #[arg(short, long)]
     out_dir: String,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,39 @@
-use config::Config;
+use std::{path::PathBuf, str::FromStr};
 
-fn main() {
-    let settings = Config::builder()
-        .add_source(config::File::with_name("config.yaml"))
-        .build()
-        .unwrap();
-    let run = kehadiran_parser::run(
-        settings.get_string("pdf_dir").unwrap(),
-        settings.get_string("out_dir").unwrap(),
+use clap::Parser;
+
+/// Simple program to greet a person
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Name of the person to greet
+    #[arg(short, long)]
+    pdf_dir: String,
+
+    /// Number of times to greet
+    #[arg(short, long)]
+    out_dir: String,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    let pdf_dir = PathBuf::from_str(&args.pdf_dir)?;
+    let out_dir = PathBuf::from_str(&args.out_dir)?;
+
+    if !pdf_dir.is_dir() {
+        return Err("pdf_dir must be a directory".into());
+    }
+
+    if !out_dir.is_dir() {
+        return Err("out_dir must be a directory".into());
+    }
+
+    println!(
+        "pdf_dir:{} out_dir:{}",
+        pdf_dir.display(),
+        out_dir.display()
     );
-    std::process::exit(run)
+
+    kehadiran_parser::run(&pdf_dir, &out_dir)?;
+    Ok(())
 }


### PR DESCRIPTION
1. Uses cmdline argument instead of config.yaml (maybe add option to use config.yaml in the future?)
2. Change main to return Result instead of using error code.
3. Validate that the given paths are indeed directories and not files.
4. Use clap to get nice UX for free

```
hbina@akarin ~/g/kehadiran-parser (hbina-update-cli-input)> cargo run --quiet -- --help                                                                                     (base) 
Program to parse PDF of Malaysian MPs attendance

Usage: kehadiran-parser --pdf-dir <PDF_DIR> --out-dir <OUT_DIR>

Options:
  -p, --pdf-dir <PDF_DIR>  Path to the PDF directory
  -o, --out-dir <OUT_DIR>  Path to the output directory
  -h, --help               Print help
  -V, --version            Print version
  ```